### PR TITLE
Add Pending - Zero-Wallet EVM 交易卡顿与挂起诊断工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,8 @@ truffle插件：
 
 [ethscan 区块链浏览器](https://ethscan.org/)
 
+[Pending - Zero-Wallet EVM 交易卡顿与挂起诊断工具](https://pending.one/) 诊断以太坊、Polygon、Base 上因 Gas 飙升或 Nonce 阻塞导致的挂起交易，提供通俗易懂的根本原因与替换参数，无需连接钱包
+
 ## 社区交流
 
 [登链社区](https://learnblockchain.cn/)


### PR DESCRIPTION
### 描述 (Description)

在「工具站点」中新增 **[Pending](https://pending.one/)**。

### 关于 Pending (About Pending)
- **网址**: https://pending.one
- **类别**: 工具站点 (Tool sites)
- **介绍**: 针对以太坊（Ethereum Mainnet）、Polygon、Base 链上的交易卡顿与挂起诊断工具。当交易因 Base Fee 飙升、连续 Nonce 阻塞或交易所热钱包排队滞留时，用户只需粘贴交易哈希即可获得通俗易懂的根本原因诊断、所需替换 Nonce 及建议 Gas 参数。100% 只读诊断，严格零钱包连接。